### PR TITLE
fix(unet.c): UnetStack v6 compatibility

### DIFF
--- a/c/unet.c
+++ b/c/unet.c
@@ -75,6 +75,13 @@ unetsocket_t unetsocket_setup(_unetsocket_t *usock){
   usock->timeout = -1;
   usock->provider = NULL;
   usock->quit = true;
+  // for new UnetStack versions (5.2.0 and later)
+  fjage_aid_t topic = fjage_aid_topic("org.arl.unet.Topics.DATAGRAM");
+  if (fjage_subscribe(usock->gw, topic) < 0) {
+    free(usock);
+    return NULL;
+  }
+  // for compatibility with older UnetStack versions (before 5.2.0)
   int nagents = agents_for_service(usock, "org.arl.unet.Services.DATAGRAM", NULL, 0);
   fjage_aid_t* agents = malloc((unsigned long)nagents*sizeof(fjage_aid_t));
   for (int i=0; i< nagents; i++) agents[i] = NULL;


### PR DESCRIPTION
This PR adds UnetStack v6 compatibility to the unetsocket C API and fixes #17. 

## TX terminal:
```
% ./samples/txdata 10.30.0.40 2 1100
Connecting to 10.30.0.40:1100
Transmitting 9 bytes of data to 2
Transmission Complete
```
## RX terminal:
```
% ./samples/rxdata 10.30.0.39 1100
Connecting to 10.30.0.39:1100
Waiting for a Datagram
Received a org.arl.unet.phy.RxFrameNtf : [1,2,3,4,5,6,7,8,9,]
Reception Complete
```