### PR TITLE
Wait unbounded for reliable datagram delivery, matching Java/Groovy

### DIFF
--- a/python/src/unetpy/socket.py
+++ b/python/src/unetpy/socket.py
@@ -55,7 +55,10 @@ class UnetSocket:
                     print(f"Received: {ntf.data}")
     """
 
-    REQUEST_TIMEOUT = 1000
+    # Bounded wait for a request AGREE/response (e.g. datagram acceptance, parameter
+    # reads). Matches the Java/Groovy UnetSocket.REQUEST_TIMEOUT. The wait for a reliable
+    # datagram's delivery notification is NOT bounded by this; see _await_send_completion.
+    REQUEST_TIMEOUT = 5000
 
     NON_BLOCKING = 0
     """When used as a timeout value, indicates a non-blocking receive().
@@ -985,9 +988,14 @@ class UnetSocket:
     def _await_send_completion(self, req: Message, delivery_only: bool) -> bool:
         if self.gw is None:
             return False
+        # Block indefinitely for the delivery/transmission notification, matched by
+        # inReplyTo == req.msgID. This mirrors the Java/Groovy UnetSocket, which waits
+        # with Gateway.BLOCKING here (only the AGREE wait is bounded by REQUEST_TIMEOUT).
+        # A bounded wait would wrongly report a successful-but-slow delivery as failed;
+        # e.g. reliable+ROBUST delivery can take several seconds.
         ntf = self.gw.receive(
             lambda msg: self._matches_send_completion(msg, req, delivery_only),
-            self.REQUEST_TIMEOUT,
+            UnetSocket.BLOCKING,
         )
         return self._is_successful_send_completion(ntf, delivery_only)
 
@@ -1010,7 +1018,10 @@ class UnetSocket:
     def _is_send_completion_notification(self, msg: Message, delivery_only: bool) -> bool:
         clazz = getattr(msg, "__clazz__", "")
         if delivery_only:
-            return isinstance(msg, (RemoteSuccessNtf, RemoteFailureNtf))
+            # A reliable datagram is acknowledged with a DatagramDeliveryNtf (success)
+            # or DatagramFailureNtf (failure). RemoteSuccessNtf/RemoteFailureNtf are
+            # subclasses of these, so this also covers remote-message delivery.
+            return isinstance(msg, (DatagramDeliveryNtf, DatagramFailureNtf))
         return (
             isinstance(
                 msg,
@@ -1023,6 +1034,8 @@ class UnetSocket:
         if msg is None:
             return False
         if delivery_only:
-            return isinstance(msg, RemoteSuccessNtf)
+            # DatagramDeliveryNtf (and its RemoteSuccessNtf subclass) => delivered.
+            # DatagramFailureNtf / RemoteFailureNtf are not DatagramDeliveryNtf => failed.
+            return isinstance(msg, DatagramDeliveryNtf)
         clazz = getattr(msg, "__clazz__", "")
         return isinstance(msg, (DatagramDeliveryNtf, RemoteSuccessNtf)) or clazz == "org.arl.unet.DatagramTransmissionNtf"

--- a/python/tests/test_socket.py
+++ b/python/tests/test_socket.py
@@ -336,7 +336,15 @@ class TestUnetSocketJavaParity:
             assert sock._resolve_provider() == remote
 
     def test_reliable_semi_blocking_send_waits_for_delivery(self, monkeypatch):
-        """Reliable semi-blocking send should wait for a delivery/failure notification."""
+        """Reliable semi-blocking send waits (unbounded) for a delivery/failure notification.
+
+        A reliable datagram is acknowledged by the stack with a DatagramDeliveryNtf
+        (delivered) or DatagramFailureNtf (failed), matched by inReplyTo. The wait must
+        be unbounded (BLOCKING): reliable delivery can take several seconds, so a bounded
+        wait would wrongly report a slow-but-successful delivery as a failure.
+        """
+        from unetpy.messages import DatagramDeliveryNtf, DatagramFailureNtf
+
         with UnetSocket(NODE_A_HOST, NODE_A_PORT) as sock:
             sock.connect(NODE_B_ADDRESS, Protocol.USER)
             sock.setReliability(True)
@@ -345,31 +353,33 @@ class TestUnetSocketJavaParity:
             class _Agree:
                 perf = Performative.AGREE
 
-            class _RemoteSuccess:
-                inReplyTo = None
-
-                def __init__(self, in_reply_to):
-                    self.inReplyTo = in_reply_to
-
-            receive_calls = {"count": 0}
             request_ids = {"value": None}
+            receive_calls = {"count": 0, "timeout": None}
 
             def _request(_req, _timeout):
                 request_ids["value"] = _req.msgID
                 return _Agree()
 
-            def _receive(_matcher, _timeout):
-                receive_calls["count"] += 1
-                msg = _RemoteSuccess(request_ids["value"])
-                return msg if _matcher(msg) else None
+            def _receive_returning(ntf_class):
+                def _receive(_matcher, _timeout):
+                    receive_calls["count"] += 1
+                    receive_calls["timeout"] = _timeout
+                    ntf = ntf_class()
+                    ntf.inReplyTo = request_ids["value"]
+                    return ntf if _matcher(ntf) else None
+                return _receive
 
             monkeypatch.setattr(sock.gw, "request", _request)
-            monkeypatch.setattr(sock.gw, "receive", _receive)
 
-            monkeypatch.setattr("unetpy.socket.RemoteSuccessNtf", _RemoteSuccess)
-
+            # Delivered -> True, and the delivery wait is unbounded (BLOCKING).
+            monkeypatch.setattr(sock.gw, "receive", _receive_returning(DatagramDeliveryNtf))
             assert sock.send([71, 72, 73]) is True
             assert receive_calls["count"] == 1
+            assert receive_calls["timeout"] == UnetSocket.BLOCKING
+
+            # Delivery failure -> False.
+            monkeypatch.setattr(sock.gw, "receive", _receive_returning(DatagramFailureNtf))
+            assert sock.send([71, 72, 73]) is False
 
     def test_set_robustness_accepts_normal(self):
         """UnetSocket should allow switching robustness back to NORMAL."""


### PR DESCRIPTION
## Problem

A reliable semi-blocking (default) `send()` should return `True` only once the datagram is **delivered**, and `False` on delivery failure — matching the Java/Groovy `UnetSocket`. Tested against a running 2-node simulator, the Python `UnetSocket` instead returns `False` for a datagram that **was** delivered:

```python
s = UnetSocket("localhost", 1101)   # node 232
s.setReliability(True)
s.setRobustness(Robustness.ROBUST)
s.send([1,2,3], to=31, protocol=Protocol.USER)   # delivered, but returns False  ✗ (Groovy: True)
s.send([1,2,3], to=32, protocol=Protocol.USER)   # unreachable, returns False        (Groovy: False)
```

The Groovy shell on the same node returns `true` for node 31 and `false` for node 32.

## Root cause

Two divergences from the [Java/Groovy `UnetSocket.send()`](https://github.com/org-arl/unet-framework) reliable path:

1. **Wrong notification class.** The reliability path matched only `RemoteSuccessNtf`/`RemoteFailureNtf`, but the stack acknowledges an ordinary reliable datagram with `DatagramDeliveryNtf` / `DatagramFailureNtf` (the `Remote*` notifications are *subclasses* of these). A real `DatagramDeliveryNtf` was therefore never recognised as completion.

2. **Bounded delivery wait.** The delivery notification was awaited for only `REQUEST_TIMEOUT` (1000 ms). Real reliable delivery routinely takes longer — reliable + ROBUST delivery in a simulated 2-node network takes a consistent **~2.6 s** — so even with (1) fixed, a successful send would still time out and report `False`. The Java/Groovy socket waits here with `Gateway.BLOCKING`; only the AGREE wait is bounded.

## Fix

- Match `DatagramDeliveryNtf`/`DatagramFailureNtf` in the reliability (`delivery_only`) path; success == `DatagramDeliveryNtf` (its `RemoteSuccessNtf` subclass included). `DatagramFailureNtf`/`RemoteFailureNtf` are sibling classes → correctly `False`.
- Await the delivery/transmission notification with `UnetSocket.BLOCKING` (unbounded), matched by `inReplyTo == req.msgID`, mirroring the Java/Groovy contract.
- Align `REQUEST_TIMEOUT` with the Java/Groovy value (5000 ms); it now scopes only the AGREE/response wait, not delivery.

## Verification

Against a running 2-node simulator (nodes 232@1101, 31@1102), reliable + ROBUST, default SEMI_BLOCKING:

| send | Groovy `UnetSocket` | unetpy (before) | unetpy (after) | latency |
|---|---|---|---|---|
| → 31 (reachable) | `true` | `False` ✗ | `True` ✓ | ~2.6 s |
| → 32 (unreachable) | `false` | `False` | `False` ✓ | ~38.7 s (stack reports failure) |

The updated unit test `test_reliable_semi_blocking_send_waits_for_delivery` now asserts a `DatagramDeliveryNtf` → `True`, a `DatagramFailureNtf` → `False`, and that the delivery wait uses `UnetSocket.BLOCKING`. It passes on this branch and fails on `master`.