### PR TITLE
Cleaner fix for the PR #21

### DIFF
--- a/python/src/unetpy/messages.py
+++ b/python/src/unetpy/messages.py
@@ -28,6 +28,7 @@ DatagramReq = MessageClass("org.arl.unet.DatagramReq")
 ParamChangeNtf = MessageClass("org.arl.unet.ParamChangeNtf")
 RefuseRsp = MessageClass("org.arl.unet.RefuseRsp")
 FailureNtf = MessageClass("org.arl.unet.FailureNtf")
+DatagramTransmissionNtf = MessageClass("org.arl.unet.DatagramTransmissionNtf")
 
 #remote
 
@@ -54,7 +55,7 @@ RxFrameNtf = MessageClass("org.arl.unet.phy.RxFrameNtf", DatagramNtf)
 RxFrameStartNtf = MessageClass("org.arl.unet.phy.RxFrameStartNtf")
 SyncInfoReq = MessageClass("org.arl.unet.phy.SyncInfoReq")
 SyncInfoRsp = MessageClass("org.arl.unet.phy.SyncInfoRsp")
-TxFrameNtf = MessageClass("org.arl.unet.phy.TxFrameNtf")
+TxFrameNtf = MessageClass("org.arl.unet.phy.TxFrameNtf", DatagramTransmissionNtf)
 TxFrameReq = MessageClass("org.arl.unet.phy.TxFrameReq", DatagramReq)
 TxFrameStartNtf = MessageClass("org.arl.unet.phy.TxFrameStartNtf")
 TxRawFrameReq = MessageClass("org.arl.unet.phy.TxRawFrameReq")

--- a/python/src/unetpy/socket.py
+++ b/python/src/unetpy/socket.py
@@ -12,13 +12,11 @@ from .constants import Protocol, Services, Topics, Address, Priority, Robustness
 from .messages import (
     AddressResolutionReq,
     DatagramDeliveryNtf,
-    DatagramFailureNtf,
     DatagramNtf,
     DatagramReq,
-    RemoteFailureNtf,
     RemoteMessageReq,
-    RemoteSuccessNtf,
     ParamChangeNtf,
+    DatagramTransmissionNtf
 )
 
 __all__ = ["UnetSocket"]
@@ -56,8 +54,7 @@ class UnetSocket:
     """
 
     # Bounded wait for a request AGREE/response (e.g. datagram acceptance, parameter
-    # reads). Matches the Java/Groovy UnetSocket.REQUEST_TIMEOUT. The wait for a reliable
-    # datagram's delivery notification is NOT bounded by this; see _await_send_completion.
+    # reads). Matches the Java/Groovy UnetSocket.REQUEST_TIMEOUT.
     REQUEST_TIMEOUT = 5000
 
     NON_BLOCKING = 0
@@ -689,18 +686,20 @@ class UnetSocket:
                 return False
             return True
 
+        wait_for_tx = getattr(req, "reliability", False)
         rsp = self.gw.request(req, self.REQUEST_TIMEOUT)
         logger.debug(f"Received response for datagram send request: {rsp}")
         if rsp is None or rsp.perf != Performative.AGREE:
             return False
-
-        if self.sendMode == UnetSocket.SEMI_BLOCKING:
-            if getattr(req, "reliability", None) is True:
-                return self._await_send_completion(req, delivery_only=True)
+        if self.sendMode == UnetSocket.SEMI_BLOCKING and not wait_for_tx:
             return True
 
         logger.debug(f"Waiting for send completion notification for datagram with reliability={getattr(req, 'reliability', None)}")
-        return self._await_send_completion(req, delivery_only=False)
+
+        ntf = self.gw.receive(req, self.BLOCKING)
+        logger.debug(f"Received send completion notification: {ntf}")
+
+        return isinstance(ntf, (DatagramDeliveryNtf, DatagramTransmissionNtf))
 
     def receive(self, timeout: Optional[int] = None) -> Optional[DatagramNtf]: # type: ignore
         """Receive a datagram sent to the local node.
@@ -985,57 +984,3 @@ class UnetSocket:
             return UnetSocket.BLOCKING
         return override
 
-    def _await_send_completion(self, req: Message, delivery_only: bool) -> bool:
-        if self.gw is None:
-            return False
-        # Block indefinitely for the delivery/transmission notification, matched by
-        # inReplyTo == req.msgID. This mirrors the Java/Groovy UnetSocket, which waits
-        # with Gateway.BLOCKING here (only the AGREE wait is bounded by REQUEST_TIMEOUT).
-        # A bounded wait would wrongly report a successful-but-slow delivery as failed;
-        # e.g. reliable+ROBUST delivery can take several seconds.
-        ntf = self.gw.receive(
-            lambda msg: self._matches_send_completion(msg, req, delivery_only),
-            UnetSocket.BLOCKING,
-        )
-        return self._is_successful_send_completion(ntf, delivery_only)
-
-    def _matches_send_completion(
-        self,
-        msg: Message,
-        req: Message,
-        delivery_only: bool,
-    ) -> bool:
-        if msg is None:
-            return False
-        if not self._is_send_completion_notification(msg, delivery_only):
-            return False
-        request_id = getattr(req, "msgID", None)
-        reply_to = getattr(msg, "inReplyTo", None)
-        if request_id is None:
-            return True
-        return reply_to == request_id
-
-    def _is_send_completion_notification(self, msg: Message, delivery_only: bool) -> bool:
-        clazz = getattr(msg, "__clazz__", "")
-        if delivery_only:
-            # A reliable datagram is acknowledged with a DatagramDeliveryNtf (success)
-            # or DatagramFailureNtf (failure). RemoteSuccessNtf/RemoteFailureNtf are
-            # subclasses of these, so this also covers remote-message delivery.
-            return isinstance(msg, (DatagramDeliveryNtf, DatagramFailureNtf))
-        return (
-            isinstance(
-                msg,
-                (DatagramDeliveryNtf, DatagramFailureNtf, RemoteSuccessNtf, RemoteFailureNtf),
-            )
-            or clazz == "org.arl.unet.DatagramTransmissionNtf"
-        )
-
-    def _is_successful_send_completion(self, msg: Optional[Message], delivery_only: bool) -> bool:
-        if msg is None:
-            return False
-        if delivery_only:
-            # DatagramDeliveryNtf (and its RemoteSuccessNtf subclass) => delivered.
-            # DatagramFailureNtf / RemoteFailureNtf are not DatagramDeliveryNtf => failed.
-            return isinstance(msg, DatagramDeliveryNtf)
-        clazz = getattr(msg, "__clazz__", "")
-        return isinstance(msg, (DatagramDeliveryNtf, RemoteSuccessNtf)) or clazz == "org.arl.unet.DatagramTransmissionNtf"

--- a/python/tests/test_socket.py
+++ b/python/tests/test_socket.py
@@ -340,46 +340,57 @@ class TestUnetSocketJavaParity:
 
         A reliable datagram is acknowledged by the stack with a DatagramDeliveryNtf
         (delivered) or DatagramFailureNtf (failed), matched by inReplyTo. The wait must
-        be unbounded (BLOCKING): reliable delivery can take several seconds, so a bounded
-        wait would wrongly report a slow-but-successful delivery as a failure.
+        be unbounded (BLOCKING): reliable delivery can take several seconds.
         """
         from unetpy.messages import DatagramDeliveryNtf, DatagramFailureNtf
 
         with UnetSocket(NODE_A_HOST, NODE_A_PORT) as sock:
-            sock.connect(NODE_B_ADDRESS, Protocol.USER)
+            sock.connect(NODE_B_ADDRESS+1, Protocol.USER)
             sock.setReliability(True)
             sock.setSendMode(UnetSocket.SEMI_BLOCKING)
 
-            class _Agree:
-                perf = Performative.AGREE
+            # check that the send method waits for a delivery notification
+            # hook the gateway's receive method to capture the received message type and the time
+            # it was called, and then call the original receive method then check that the send method
+            # returns False and that it returned AFTER the receive method was called (i.e. it waited for the notification)
+            original_receive = getattr(sock.gw, "receive")
+            received_message_type = None
+            receive_called_time = None
 
-            request_ids = {"value": None}
-            receive_calls = {"count": 0, "timeout": None}
+            def receive_hook(*args, **kwargs):
+                nonlocal received_message_type, receive_called_time
+                receive_called_time = time.time()
+                ntf = original_receive(*args, **kwargs)
+                if isinstance(ntf, DatagramDeliveryNtf):
+                    received_message_type = "DatagramDeliveryNtf"
+                elif isinstance(ntf, DatagramFailureNtf):
+                    received_message_type = "DatagramFailureNtf"
+                return ntf
 
-            def _request(_req, _timeout):
-                request_ids["value"] = _req.msgID
-                return _Agree()
+            monkeypatch.setattr(sock.gw, "receive", receive_hook)
+            start_time = time.time()
+            result = sock.send([71, 72, 73])
+            end_time = time.time()
 
-            def _receive_returning(ntf_class):
-                def _receive(_matcher, _timeout):
-                    receive_calls["count"] += 1
-                    receive_calls["timeout"] = _timeout
-                    ntf = ntf_class()
-                    ntf.inReplyTo = request_ids["value"]
-                    return ntf if _matcher(ntf) else None
-                return _receive
+            assert result is False
+            assert received_message_type in {"DatagramFailureNtf"}
+            assert receive_called_time is not None
+            assert end_time >= receive_called_time, "send method did not wait for notification"
 
-            monkeypatch.setattr(sock.gw, "request", _request)
+            # change the destination to a valid one and check that the send method returns True for a delivery notification
+            # but also after the receive method was called (i.e. it waited for the notification)
+            sock.disconnect()
+            sock.connect(NODE_B_ADDRESS, Protocol.USER)
+            received_message_type = None
+            receive_called_time = None
+            start_time = time.time()
+            result = sock.send([74, 75, 76])
+            end_time = time.time()
 
-            # Delivered -> True, and the delivery wait is unbounded (BLOCKING).
-            monkeypatch.setattr(sock.gw, "receive", _receive_returning(DatagramDeliveryNtf))
-            assert sock.send([71, 72, 73]) is True
-            assert receive_calls["count"] == 1
-            assert receive_calls["timeout"] == UnetSocket.BLOCKING
-
-            # Delivery failure -> False.
-            monkeypatch.setattr(sock.gw, "receive", _receive_returning(DatagramFailureNtf))
-            assert sock.send([71, 72, 73]) is False
+            assert result is True
+            assert received_message_type in {"DatagramDeliveryNtf"}
+            assert receive_called_time is not None
+            assert end_time >= receive_called_time, "send method did not wait for notification"
 
     def test_set_robustness_accepts_normal(self):
         """UnetSocket should allow switching robustness back to NORMAL."""


### PR DESCRIPTION
This pull request refactors the datagram send completion logic in the `UnetSocket` class to simplify notification handling and improve clarity. It removes the previous complex matcher-based approach for awaiting send completion, instead directly checking for relevant notification types. The changes also introduce support for the new `DatagramTransmissionNtf` message type and update tests to reflect the new logic.